### PR TITLE
Do not clear cache when no uri for stream

### DIFF
--- a/src/Stream.php
+++ b/src/Stream.php
@@ -113,7 +113,10 @@ class Stream implements MetadataStreamInterface
         }
 
         // If the stream is a file based stream and local, then use fstat
-        clearstatcache(true, $this->meta['uri']);
+        if (isset($this->meta['uri'])) {
+            clearstatcache(true, $this->meta['uri']);
+        }
+
         $stats = fstat($this->stream);
         if (isset($stats['size'])) {
             $this->size = $stats['size'];


### PR DESCRIPTION
A stream may not have an uri in it's metadata, for example when using proc_open with pipes, the read pipe does not have an uri.

This should not be a problem for stats has php does not cache the stats when the file does not exists.
