### PR TITLE
[Stream] Close should clear properties

### DIFF
--- a/src/Stream.php
+++ b/src/Stream.php
@@ -105,7 +105,7 @@ class Stream implements MetadataStreamInterface
         }
 
         $this->meta = [];
-        $this->stream = null;
+        $this->detach();
     }
 
     public function detach()

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -151,6 +151,19 @@ class StreamTest extends \PHPUnit_Framework_TestCase
         $stream->close();
     }
 
+    public function testCloseClearProperties()
+    {
+        $handle = fopen('php://temp', 'r+');
+        $stream = new Stream($handle);
+        $stream->close();
+
+        $this->assertEmpty($stream->getMetadata());
+        $this->assertFalse($stream->isSeekable());
+        $this->assertFalse($stream->isReadable());
+        $this->assertFalse($stream->isWritable());
+        $this->assertNull($stream->getSize());
+    }
+
     public function testCreatesWithFactory()
     {
         $stream = Stream::factory('foo');


### PR DESCRIPTION
Hey!

This PR clears the stream properties when it is closed as it becomes unusable and the getter/isser should reflect this state.
