### PR TITLE
[Stream] __toString() should keep the position of the resource

### DIFF
--- a/src/Stream.php
+++ b/src/Stream.php
@@ -86,9 +86,12 @@ class Stream implements MetadataStreamInterface
             return '';
         }
 
+        $offset = $this->tell();
         $this->seek(0);
+        $string = (string) stream_get_contents($this->stream);
+        $this->seek($offset);
 
-        return (string) stream_get_contents($this->stream);
+        return $string;
     }
 
     public function getContents($maxLength = -1)

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -164,6 +164,18 @@ class StreamTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($stream->getSize());
     }
 
+    public function testToStringKeepPositionOfResource()
+    {
+        $handle = fopen('php://temp', 'r+');
+        fwrite($handle, 'data');
+        fseek($handle, 2);
+
+        $stream = new Stream($handle);
+
+        $this->assertSame('data', (string) $stream);
+        $this->assertSame(2, $stream->tell());
+    }
+
     public function testCreatesWithFactory()
     {
         $stream = Stream::factory('foo');


### PR DESCRIPTION
Hey!

This PR maintains the resource position when a to string conversion is done.
