### PR TITLE
Fix LimitStream::seek() to accept relative offset

### DIFF
--- a/src/LimitStream.php
+++ b/src/LimitStream.php
@@ -70,8 +70,10 @@ class LimitStream implements StreamInterface, MetadataStreamInterface
             return false;
         }
 
-        if ($offset < $this->offset) {
+        if ($offset < 0) {
             $offset = $this->offset;
+        } else {
+            $offset += $this->offset;
         }
 
         if ($this->limit !== -1 && $offset > ($this->offset + $this->limit)) {

--- a/tests/LimitStreamTest.php
+++ b/tests/LimitStreamTest.php
@@ -56,11 +56,18 @@ class LimitStreamTest extends \PHPUnit_Framework_TestCase
 
     public function testAllowsBoundedSeek()
     {
-        $this->body->seek(100);
+        $this->assertEquals(true, $this->body->seek(100));
+        $this->assertEquals(10, $this->body->tell());
         $this->assertEquals(13, $this->decorated->tell());
-        $this->body->seek(0);
+        $this->assertEquals(true, $this->body->seek(0));
         $this->assertEquals(0, $this->body->tell());
         $this->assertEquals(3, $this->decorated->tell());
+        $this->assertEquals(true, $this->body->seek(-10));
+        $this->assertEquals(0, $this->body->tell());
+        $this->assertEquals(3, $this->decorated->tell());
+        $this->assertEquals(true, $this->body->seek(5));
+        $this->assertEquals(5, $this->body->tell());
+        $this->assertEquals(8, $this->decorated->tell());
         $this->assertEquals(false, $this->body->seek(1000, SEEK_END));
     }
 


### PR DESCRIPTION
Currently, `$stream->seek($x); $x=$stream->tell()` are not symmetric, x will change if the LimitStream offset is not 0.

Also, LimitStream::seek() expects its argument to be an absolute offset in the wrapped stream, not relative to the offset. This breaks the abstraction.

This pull request fixes the LimitStream::seek() so it expects an offset in range 0..limit relative to offset and then tell() will properly return the same value.
