### PR TITLE
Fix Utils::readline() for Windows. Add optional $eol. Change $maxLength

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -155,13 +155,15 @@ class Utils
      *
      * @param StreamInterface $stream    Stream to read from
      * @param int             $maxLength Maximum buffer length
+     * @param string          $eol       Line ending
      *
      * @return string|bool
      */
-    public static function readline(StreamInterface $stream, $maxLength = null)
+    public static function readline(StreamInterface $stream, $maxLength = null, $eol = PHP_EOL)
     {
         $buffer = '';
         $size = 0;
+        $negEolLen = -strlen($eol);
 
         while (!$stream->eof()) {
             if (false === ($byte = $stream->read(1))) {
@@ -169,7 +171,7 @@ class Utils
             }
             $buffer .= $byte;
             // Break when a new line is found or the max length - 1 is reached
-            if ($byte == PHP_EOL || ++$size == $maxLength - 1) {
+            if (++$size == $maxLength || substr($buffer, $negEolLen) === $eol) {
                 break;
             }
         }

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -73,17 +73,24 @@ class UtilsTest extends \PHPUnit_Framework_TestCase
 
     public function testReadsLines()
     {
-        $s = Stream::factory("foo\nbaz\nbar");
-        $this->assertEquals("foo\n", Utils::readline($s));
-        $this->assertEquals("baz\n", Utils::readline($s));
+        $s = Stream::factory("foo" . PHP_EOL . "baz" . PHP_EOL . "bar");
+        $this->assertEquals("foo" . PHP_EOL, Utils::readline($s));
+        $this->assertEquals("baz" . PHP_EOL, Utils::readline($s));
         $this->assertEquals("bar", Utils::readline($s));
     }
 
     public function testReadsLinesUpToMaxLength()
     {
-        $s = Stream::factory("12345\n");
-        $this->assertEquals("123", Utils::readline($s, 4));
-        $this->assertEquals("45\n", Utils::readline($s));
+        $s = Stream::factory("12345" . PHP_EOL);
+        $this->assertEquals("123", Utils::readline($s, 3));
+        $this->assertEquals("45" . PHP_EOL, Utils::readline($s));
+    }
+
+    public function testReadsLinesWithCustomEol()
+    {
+        $s = Stream::factory("foo\tbaz\t\tbar");
+        $this->assertEquals("foo\tbaz\t\t", Utils::readline($s, null, "\t\t"));
+        $this->assertEquals("bar", Utils::readline($s));
     }
 
     public function testReadsLineUntilFalseReturnedFromRead()


### PR DESCRIPTION
PHP_EOL is used in Utils::readline(). First problem is clear: PHP_EOL is two-character on windows, so `$byte == PHP_EOL` will never match. This may be solved with either `$byte === substr(PHP_EOL, -1)` or `substr($buffer, -strlen(PHP_EOL)) === PHP_EOL`

Second problem is less obvious. If this function is used to read the stream opened with fopen() in text mode, read bytes will be already translated to "\n". If this function is used to read some network protocol, then protocol EOL may differ from platform EOL. So use of PHP_EOL is not right. The only way I see to fix this is providing optional parameter `$eol = PHP_EOL`.

Unrelated fix is regarding `++$size == $maxLength - 1` which means only $maxLength - 1 buffer size is allowed, not $maxLength. It looks intentional, but not clearly stated, so I've fixed it to use full $maxLength.
