### PR TITLE
Fix #29 feof need a failed read

### DIFF
--- a/tests/AppendStreamTest.php
+++ b/tests/AppendStreamTest.php
@@ -109,6 +109,7 @@ class AppendStreamTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $a->read(3));
         $this->assertEquals('bar', $a->read(3));
         $this->assertEquals('baz', $a->read(3));
+        $this->assertEmpty($a->read(1));
         $this->assertTrue($a->eof());
         $this->assertSame(9, $a->tell());
         $this->assertEquals('foobarbaz', (string) $a);

--- a/tests/FnStreamTest.php
+++ b/tests/FnStreamTest.php
@@ -59,6 +59,7 @@ class FnStreamTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($b->read(3), 'foo');
         $this->assertEquals($b->tell(), 3);
         $this->assertEquals($a->tell(), 3);
+        $this->assertEmpty($b->read(1));
         $this->assertEquals($b->eof(), true);
         $this->assertEquals($a->eof(), true);
         $b->seek(0);

--- a/tests/GuzzleStreamWrapperTest.php
+++ b/tests/GuzzleStreamWrapperTest.php
@@ -18,6 +18,7 @@ class GuzzleStreamWrapperTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(3, fwrite($handle, 'bar'));
         $this->assertSame(0, fseek($handle, 0));
         $this->assertSame('foobar', fread($handle, 6));
+        $this->assertEmpty(fread($handle, 1));
         $this->assertTrue(feof($handle));
 
         // This fails on HHVM for some reason

--- a/tests/LimitStreamTest.php
+++ b/tests/LimitStreamTest.php
@@ -31,6 +31,7 @@ class LimitStreamTest extends \PHPUnit_Framework_TestCase
         $body->seek(0);
         $this->assertFalse($body->eof());
         $this->assertEquals('oo', $body->read(100));
+        $this->assertEmpty($body->read(1));
         $this->assertTrue($body->eof());
     }
 


### PR DESCRIPTION
PHP 5.5.21 / 5.6.5 are going to be released tomorrow, with this change which make file stream and memory consistent.