### PR TITLE
Utils::readline never seem to return false

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -157,7 +157,7 @@ class Utils
      * @param int             $maxLength Maximum buffer length
      * @param string          $eol       Line ending
      *
-     * @return string|bool
+     * @return string
      */
     public static function readline(StreamInterface $stream, $maxLength = null, $eol = PHP_EOL)
     {


### PR DESCRIPTION
The return comment on Utils::readline suggests that readline van return false but it never seem to do so. I found the comment misleading because i thought i could call readline until the end of the file. (on which it hopefully returned false)

But it keeps returning an empty string.
I removed false from the return comment to make it more clear.

I also made a PR which does return false on eof
(Not more then one of these PR's should be merged)

Cheers
