### PR TITLE
Make Utils::readline return false when there was nothing to read

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -161,11 +161,15 @@ class Utils
      */
     public static function readline(StreamInterface $stream, $maxLength = null, $eol = PHP_EOL)
     {
+        if ($stream->eof()) {
+            return false;
+        }
+
         $buffer = '';
         $size = 0;
         $negEolLen = -strlen($eol);
 
-        while (!$stream->eof()) {
+        do {
             if (false === ($byte = $stream->read(1))) {
                 return $buffer;
             }
@@ -174,7 +178,7 @@ class Utils
             if (++$size == $maxLength || substr($buffer, $negEolLen) === $eol) {
                 break;
             }
-        }
+        } while (!$stream->eof());
 
         return $buffer;
     }

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -93,6 +93,15 @@ class UtilsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("bar", Utils::readline($s));
     }
 
+    public function testReadLinesReturnFalseOnEol()
+    {
+        $s = Stream::factory("foo" . PHP_EOL . PHP_EOL . "bar");
+        $this->assertEquals("foo" . PHP_EOL, Utils::readline($s));
+        $this->assertEquals(PHP_EOL, Utils::readline($s));
+        $this->assertEquals("bar", Utils::readline($s));
+        $this->assertFalse(Utils::readline($s));
+    }
+
     public function testReadsLineUntilFalseReturnedFromRead()
     {
         $s = $this->getMockBuilder('GuzzleHttp\Stream\Stream')


### PR DESCRIPTION
The return comment for Utils::readline suggest that readline can return false but it never does. This PR will make readline return false when it hits the eof.

If that is not the behaviour what you want then i suggest to remove the false from the return comment to make this more explicit.

I also made a PR to do that.
(Not more then one of these PR's should be merged)

Cheers
